### PR TITLE
Add reserved name 'stdout' for file output, referring to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ tail -c +1 -f /tmp/dump_file | tcpdump -r -
 ```
 
 ```bash
-# Edit the configuration to write to /dev/stdout, and pipe output to tcpdump:
-./packet-streamer receiver --config contrib/receiver-stdout.yaml | tcpdump -r -
+# Edit the configuration to write to the special name 'stdout', and pipe output to tcpdump:
+./packet-streamer receiver --config ./contrib/config/receiver-stdout.yaml | tcpdump -r -
 ```
 
 ## Run a PacketStreamer sensor
@@ -238,7 +238,7 @@ output:
     address: _ip-address_
     port: _listen-port_
   file:                        # required in 'receiver' mode
-    path: _filename_
+    path: _filename_|stdout    # 'stdout' is a reserved name. Receiver will write to stdout
 tls:                           # optional
   enable: _true_|_false_
   certfile: _filename_

--- a/contrib/config/receiver-stdout.yaml
+++ b/contrib/config/receiver-stdout.yaml
@@ -3,4 +3,4 @@ input:
   port: 8081
 output:
   file:
-    path: /dev/stdout
+    path: stdout

--- a/pkg/streamer/common.go
+++ b/pkg/streamer/common.go
@@ -71,9 +71,13 @@ func InitOutput(config *config.Config, proto string) error {
 	if config.Output.File != nil {
 		var pcapBuffer bytes.Buffer
 		pcapWriter := pcapgo.NewWriter(&pcapBuffer)
-		fileFd, err := os.OpenFile(config.Output.File.Path, os.O_CREATE|os.O_RDWR, 0666)
-		if err != nil {
-			return err
+		fileFd := os.Stdout
+		if config.Output.File.Path != "stdout" {
+			var err error
+			fileFd, err = os.OpenFile(config.Output.File.Path, os.O_CREATE|os.O_RDWR, 0644)
+			if err != nil {
+				return err
+			}
 		}
 		pcapWriter.WriteFileHeader(uint32(config.InputPacketLen), layers.LinkTypeEthernet)
 		fileFd.Write(pcapBuffer.Bytes())


### PR DESCRIPTION
**Add reserved name 'stdout' for file output to stdout.**

This is useful when sending output from the receiver to another process (e.g. tcpdump) which reads from stdin, as it avoids the intermediate file and allows for a more concise, single-line usage:

`packetStreamer receiver --config receiver-stdout.yaml | tcpdump -r -`

Note: the usual convention is to use the filename '-' to refer to stdout, but '-' cannot be used in the yaml configuration as it is a reserved symbol.

Update README.md accordingly.  Also a minor fix to the file permissions for the output file