### PR TITLE
Fix for slice out of boundary on compression

### DIFF
--- a/pkg/streamer/common.go
+++ b/pkg/streamer/common.go
@@ -134,7 +134,7 @@ func printDataSize() {
 	currSize := totalDataSize
 	v := []string{"B", "KB", "MB", "GB", "TB", "PB", "EB"}
 	l := 0
-	for ; currSize > 1024; currSize = currSize / 1024 {
+	for ; currSize > kilobyte; currSize = currSize / kilobyte {
 		l++
 	}
 	log.Printf("Total data transfer size is %d %s\n", currSize, v[l])


### PR DESCRIPTION
Compression might reach a state where compressed data size is actually
bigger that original data. For those cases, we need to send original
data instead.
The fix make sure sensor won't send data bigger than original data.
Receiver will know if it needs to uncompressed via an extra header flag check.