### PR TITLE
Add timeout to send captured packets early

### DIFF
--- a/contrib/helm/templates/configmap.yaml
+++ b/contrib/helm/templates/configmap.yaml
@@ -51,6 +51,7 @@ data:
 {{- end }}
     compressBlockSize: {{ .Values.sensor.compressBlockSize }}
     inputPacketLen: {{ .Values.sensor.inputPacketLen }}
+    gatherMaxWaitSec: {{ .Values.sensor.gatherMaxWaitSec }}
 {{- if hasKey .Values.sensor "logFilename" }}
     logFilename: {{ .Values.sensor.logFilename }}
 {{- end }}

--- a/contrib/helm/values.yaml
+++ b/contrib/helm/values.yaml
@@ -39,6 +39,7 @@ sensor:
     key: ""
   compressBlockSize: 65
   inputPacketLen: 65535
+  gatherMaxWaitSec: 5
   # logFilename: ""
   pcapMode: all
   # capturePorts: _list-of-ports_

--- a/docs-mdbook/src/configuration.md
+++ b/docs-mdbook/src/configuration.md
@@ -29,6 +29,7 @@ auth:                              # optional; receiver and sensor must use same
   key: _string_
 compressBlockSize: _integer_       # optional; default: 65
 inputPacketLen: _integer_          # optional; default: 65535
+gatherMaxWaitSec: _integer_        # optional; default: 5
 logFilename: _filename_            # optional
 pcapMode: _Allow_|_Deny_|_All_     # optional
 capturePorts: _list-of-ports_      # optional

--- a/docs/docs/packetstreamer/configuration.md
+++ b/docs/docs/packetstreamer/configuration.md
@@ -33,6 +33,7 @@ auth:                              # optional; receiver and sensor must use same
   key: string
 compressBlockSize: integer         # optional; default: 65
 inputPacketLen: integer            # optional; default: 65535
+gatherMaxWaitSec: integer          # optional; default: 5
 logFilename: filename              # optional
 pcapMode: Allow|Deny|All           # optional
 capturePorts: list-of-ports        # optional

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -128,6 +128,7 @@ type RawConfig struct {
 	Auth                   AuthConfig
 	CompressBlockSize      *int             `yaml:"compressBlockSize,omitempty"`
 	InputPacketLen         *int             `yaml:"inputPacketLen,omitempty"`
+	GatherMaxWaitSec       *int             `yaml:"gatherMaxWaitSec,omitempty"`
 	LogFilename            string           `yaml:"logFilename,omitempty"`
 	PcapMode               string           `yaml:"pcapMode,omitempty"`
 	CapturePorts           []int            `yaml:"capturePorts,omitempty"`
@@ -151,6 +152,7 @@ type Config struct {
 	MaxGatherLen           int
 	MaxPayloadLen          int
 	MaxHeaderLen           int
+	MaxGatherWait          time.Duration
 }
 
 func NewConfig(configFileName string) (*Config, error) {
@@ -189,6 +191,11 @@ func NewConfig(configFileName string) (*Config, error) {
 	inputPacketLen := 65535
 	if rawConfig.InputPacketLen != nil {
 		inputPacketLen = *rawConfig.InputPacketLen
+	}
+
+	gatherMaxWaitSec := 5
+	if rawConfig.GatherMaxWaitSec != nil {
+		gatherMaxWaitSec = *rawConfig.GatherMaxWaitSec
 	}
 
 	var pcapMode PcapMode
@@ -230,6 +237,7 @@ func NewConfig(configFileName string) (*Config, error) {
 		},
 		MaxEncodedLen: s2.MaxEncodedLen(compressBlockSize * kilobyte),
 		MaxGatherLen:  compressBlockSize * kilobyte,
+		MaxGatherWait: time.Duration(gatherMaxWaitSec) * time.Second,
 		MaxPayloadLen: s2.MaxEncodedLen(compressBlockSize*kilobyte) + /*hdrData*/ 4 + /*payloadMarker*/ 4,
 		MaxHeaderLen:  + /*hdrData*/ 4 + /*payloadMarker*/ 4,
 	}


### PR DESCRIPTION
Prior to that change, packets were only sent when the gather capacity was reached. On low traffic, this means data is sent very rarely (and might end up being lost).

The proposed change adds a configurable timeout mechanism. If the timeout is reached before the capacity is full, captured packets are sent over to the receiver.